### PR TITLE
Adding ability to not install katello-agent

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,13 @@
 Metrics/AbcSize:
   Max: 30
+Metrics/CyclomaticComplexity:
+  Max: 10
 Metrics/LineLength:
   Max: 150
 Metrics/MethodLength:
   Max: 30
+Metrics/PerceivedComplexity:
+  Max: 10
 Style/Documentation:
   Enabled: false
 Style/SignalException:

--- a/libraries/rhsm_register.rb
+++ b/libraries/rhsm_register.rb
@@ -22,14 +22,15 @@ module RhsmCookbook
 
     resource_name :rhsm_register
 
-    property :_name_unused,        kind_of: String, name_property: true
-    property :activation_key,      kind_of: [ String, Array ]
-    property :satellite_host,      kind_of: String
-    property :organization,        kind_of: String
-    property :environment,         kind_of: String
-    property :username,            kind_of: String
-    property :password,            kind_of: String
-    property :auto_attach,         kind_of: [ TrueClass, FalseClass ], default: false
+    property :_name_unused,          kind_of: String, name_property: true
+    property :activation_key,        kind_of: [ String, Array ]
+    property :satellite_host,        kind_of: String
+    property :organization,          kind_of: String
+    property :environment,           kind_of: String
+    property :username,              kind_of: String
+    property :password,              kind_of: String
+    property :auto_attach,           kind_of: [ TrueClass, FalseClass ], default: false
+    property :install_katello_agent, kind_of: [ TrueClass, FalseClass ], default: true
 
     action :register do
       remote_file "#{Chef::Config[:file_cache_path]}/katello-package.rpm" do
@@ -58,6 +59,7 @@ module RhsmCookbook
 
       yum_package 'katello-agent' do
         action :install
+        only_if { install_katello_agent }
       end
     end
 

--- a/spec/unit/resources_spec.rb
+++ b/spec/unit/resources_spec.rb
@@ -39,11 +39,11 @@ describe 'rhsm_test::unit' do
         allow_any_instance_of(Chef::Resource).to receive(:satellite_host).and_return('sathost')
       end
 
-      it 'fetches the katello RPM' do
+      it 'fetches the katello cert and config RPM' do
         expect(chef_run).to create_remote_file('/tmp/chefspec/katello-package.rpm')
       end
 
-      it 'installs the katello package' do
+      it 'installs the katello cert and config RPM' do
         expect(remote_file).to notify('yum_package[katello-ca-consumer-latest]').to(:install)
       end
     end
@@ -71,12 +71,21 @@ describe 'rhsm_test::unit' do
       end
     end
 
-    it 'deletes the katello RPM file' do
+    it 'deletes the katello cert and config RPM file' do
       expect(chef_run).to delete_file('/tmp/chefspec/katello-package.rpm')
     end
 
-    it 'installs the katello-agent package' do
-      expect(chef_run).to install_yum_package('katello-agent')
+    context 'when install_katello_agent is false' do
+      it 'does not install the katello-agent' do
+        allow_any_instance_of(Chef::Resource).to receive(:install_katello_agent).and_return(false)
+        expect(chef_run).to_not install_yum_package('katello-agent')
+      end
+    end
+
+    context 'when install_katello_agent is true (default)' do
+      it 'installs the katello-agent package' do
+        expect(chef_run).to install_yum_package('katello-agent')
+      end
     end
 
     it 'converges successfully' do


### PR DESCRIPTION
Even though the katello-agent is required for proper Red Hat
Satellite functionality and is recommended by Red Hat, some users
are using this cookbook to just manage their registration and
errata. This change will allow a user to opt-out of having the
Katello agent installed on their node.

Addresses #3.
