### PR TITLE
Install yum-plugin-security to ensure --sec-severity works on rhel6

### DIFF
--- a/libraries/rhsm_errata_level.rb
+++ b/libraries/rhsm_errata_level.rb
@@ -26,7 +26,11 @@ module RhsmCookbook
 
     action :install do
       validate_errata_level!(errata_level)
-
+        if node['platform_version'].to_i == 6
+          yum_package 'yum-plugin-security' do
+          action :install
+        end
+      end
       execute "Install any #{errata_level} errata" do
         command "yum update --sec-severity=#{errata_level.capitalize} -y"
         action :run

--- a/libraries/rhsm_errata_level.rb
+++ b/libraries/rhsm_errata_level.rb
@@ -26,8 +26,8 @@ module RhsmCookbook
 
     action :install do
       validate_errata_level!(errata_level)
-        if node['platform_version'].to_i == 6
-          yum_package 'yum-plugin-security' do
+      if node['platform_version'].to_i == 6
+        yum_package 'yum-plugin-security' do
           action :install
         end
       end

--- a/libraries/rhsm_errata_level.rb
+++ b/libraries/rhsm_errata_level.rb
@@ -26,10 +26,9 @@ module RhsmCookbook
 
     action :install do
       validate_errata_level!(errata_level)
-      if node['platform_version'].to_i == 6
-        yum_package 'yum-plugin-security' do
-          action :install
-        end
+      yum_package 'yum-plugin-security' do
+        action :install
+        only_if { node['platform_version'].to_i == 6 }
       end
       execute "Install any #{errata_level} errata" do
         command "yum update --sec-severity=#{errata_level.capitalize} -y"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'partnereng@chef.io'
 license 'Apache 2.0'
 description 'Provides custom resources to interact with Red Hat Subscription Manager (RHSM) and Red Hat Satellite'
 long_description 'Provides custom resources to interact with Red Hat Subscription Manager (RHSM) and Red Hat Satellite'
-version '0.2.0'
+version '0.2.1'
 source_url 'https://github.com/chef-partners/redhat-subscription-manager-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/chef-partners/redhat-subscription-manager-cookbook/issues' if respond_to?(:issues_url)
 

--- a/spec/unit/resources_spec.rb
+++ b/spec/unit/resources_spec.rb
@@ -200,9 +200,25 @@ describe 'rhsm_test::unit' do
 
   context 'when the host is rhel6' do
     let(:chef_run) do
-      it 'installs the yum-plugin-security package' do
-        expect(chef_run).to install_yum_package('yum-plugin-security')
-      end
+      ChefSpec::ServerRunner.new(
+        platform: 'redhat', version: '6.1',
+        step_into: 'rhsm_errata_level'
+      ).converge(described_recipe)
+    end
+    it 'installs the yum-plugin-security package' do
+      expect(chef_run).to install_yum_package('yum-plugin-security')
+    end
+  end
+
+  context 'when the host is rhel7' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(
+        platform: 'redhat', version: '7.1',
+        step_into: 'rhsm_errata_level'
+      ).converge(described_recipe)
+    end
+    it 'doesnt install the yum-plugin-security package' do
+      expect(chef_run).to_not install_yum_package('yum-plugin-security')
     end
   end
 

--- a/spec/unit/resources_spec.rb
+++ b/spec/unit/resources_spec.rb
@@ -198,6 +198,14 @@ describe 'rhsm_test::unit' do
     end
   end
 
+  context 'when the host is rhel6' do
+    let(:chef_run) do
+      it 'installs the yum-plugin-security package' do
+        expect(chef_run).to install_yum_package('yum-plugin-security')
+      end
+    end
+  end
+
   context 'rhsm_errata_level' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new(

--- a/spec/unit/resources_spec.rb
+++ b/spec/unit/resources_spec.rb
@@ -210,18 +210,6 @@ describe 'rhsm_test::unit' do
     end
   end
 
-  context 'when the host is rhel7' do
-    let(:chef_run) do
-      ChefSpec::ServerRunner.new(
-        platform: 'redhat', version: '7.1',
-        step_into: 'rhsm_errata_level'
-      ).converge(described_recipe)
-    end
-    it 'doesnt install the yum-plugin-security package' do
-      expect(chef_run).to_not install_yum_package('yum-plugin-security')
-    end
-  end
-
   context 'rhsm_errata_level' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new(


### PR DESCRIPTION
When installing errata on RHEL6, the yum option '--sec-severity' will not work unless the 'yum-plugin-security'  package is installed.  This appears to be just a part of yum in RHEL7.  This will add the package if needed when installing errata. 
