### PR TITLE
add force registration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ with RHSM or your local Satellite server.
 * **auto_attach**: if true, RHSM will attempt to automatically attach the host to applicable subscriptions. It is generally better to use an activation key with the subscriptions pre-defined.
 * **install_katello_agent**: if true, the `katello-agent` RPM will be installed. Defaults to `true`
 * **sensitive**: if true, the execution of the registration command will be flagged as "sensitive," prohibiting the command, STDOUT, and STDERR from being displayed in the Chef log output. This command could contain usernames, passwords, and activation keys, so unlike other Chef resources, this defaults to `true`. However, you may set it to `false` to get additional output if your registration attempts are failing.
+* **force**: if true, the system will be registered even if it is already registered. Normally, any register operations will fail if the machine is has already registered.
 
 #### Examples
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -28,6 +28,7 @@ module RhsmCookbook
 
         command << activation_keys.map { |key| "--activationkey=#{Shellwords.shellescape(key)}" }
         command << "--org=#{Shellwords.shellescape(organization)}"
+        command << "--force" if force
 
         return command.join(' ')
       end
@@ -39,6 +40,7 @@ module RhsmCookbook
         command << "--password=#{Shellwords.shellescape(password)}"
         command << "--environment=#{Shellwords.shellescape(environment)}" if using_satellite_host?
         command << '--auto-attach' if auto_attach
+        command << "--force" if force
 
         return command.join(' ')
       end

--- a/libraries/rhsm_register.rb
+++ b/libraries/rhsm_register.rb
@@ -32,6 +32,7 @@ module RhsmCookbook
     property :auto_attach,           kind_of: [ TrueClass, FalseClass ], default: false
     property :install_katello_agent, kind_of: [ TrueClass, FalseClass ], default: true
     property :sensitive,             kind_of: [ TrueClass, FalseClass ], default: true
+    property :force,                 kind_of: [ TrueClass, FalseClass ], default: false
 
     action :register do
       remote_file "#{Chef::Config[:file_cache_path]}/katello-package.rpm" do


### PR DESCRIPTION
In some cases, like CI pipelines where machine names or VMs are reused the subscription state may not be relevant. Adding the force options helps reduce errors like:

`Consumer profile "57c1a128-7463-40e1-b70d-08f826a2eab8" has been deleted from the server. You can use command clean or unregister to remove local profile`