### PR TITLE
override languages in environment when running commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,13 @@ rhsm_errata_level 'IMPORTANT' do
 end
 ```
 
+Attributes
+----------
+
+* `node['rhsm']['lang']` - Sets the environment language with that subscription-manager commands are executed. The output of that command is
+localized and non English output breaks the output parsing of this cookbook. Therefore changing the default may break this cookbook.
+Defaults to `'en_US'`.
+
 License and Authors
 -------------------
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,5 @@
+# <
+# Sets the environment language with that subscription-manager commands are executed. The output of that command is localized and non English
+# output breaks the output parsing of this cookbook. Therefore changing the default may break this cookbook.
+# >
+default['rhsm']['lang'] = 'en_US'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -57,7 +57,7 @@ module RhsmCookbook
     end
 
     def registered_with_rhsm?
-      cmd = Mixlib::ShellOut.new('subscription-manager status')
+      cmd = Mixlib::ShellOut.new('subscription-manager status', env: { LANG: node['rhsm']['lang'] })
       cmd.run_command
       !cmd.stdout.match(/Overall Status: Unknown/)
     end
@@ -69,13 +69,13 @@ module RhsmCookbook
     end
 
     def subscription_attached?(subscription)
-      cmd = Mixlib::ShellOut.new("subscription-manager list --consumed | grep #{subscription}")
+      cmd = Mixlib::ShellOut.new("subscription-manager list --consumed | grep #{subscription}", env: { LANG: node['rhsm']['lang'] })
       cmd.run_command
       !cmd.stdout.match(/Pool ID:\s+#{subscription}$/).nil?
     end
 
     def repo_enabled?(repo)
-      cmd = Mixlib::ShellOut.new('subscription-manager repos --list-enabled')
+      cmd = Mixlib::ShellOut.new('subscription-manager repos --list-enabled', env: { LANG: node['rhsm']['lang'] })
       cmd.run_command
       !cmd.stdout.match(/Repo ID:\s+#{repo}$/).nil?
     end
@@ -90,7 +90,7 @@ module RhsmCookbook
       pool = nil
       serial = nil
 
-      cmd = Mixlib::ShellOut.new('subscription-manager list --consumed')
+      cmd = Mixlib::ShellOut.new('subscription-manager list --consumed', env: { LANG: node['rhsm']['lang'] })
       cmd.run_command
       cmd.stdout.lines.each do |line|
         line.strip!


### PR DESCRIPTION
Fix for https://github.com/chef-partners/redhat-subscription-manager-cookbook/issues/32