### PR TITLE
fix only_if for katello-agent install

### DIFF
--- a/libraries/rhsm_register.rb
+++ b/libraries/rhsm_register.rb
@@ -60,7 +60,7 @@ module RhsmCookbook
 
       yum_package 'katello-agent' do
         action :install
-        only_if { new_resource.install_katello_agent && new_resource.satellite_host }
+        only_if { new_resource.install_katello_agent && !new_resource.satellite_host.nil? }
       end
     end
 


### PR DESCRIPTION
…<hemminger@hotmail.com>

Signed-off-by: corey hemminger <hemminger@hotmail.com>

### Description

fixes issue with katello-agent install resource not_if guard.

### Issues Resolved

#38 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
