### PR TITLE
Fix username/password based registration

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -23,14 +23,16 @@ module RhsmCookbook
     def register_command
       command = %w(subscription-manager register)
 
-      unless new_resource.activation_key.empty?
-        raise 'Unable to register - you must specify organization when using activation keys' if new_resource.organization.nil?
+      if new_resource.activation_key
+        unless new_resource.activation_key.empty?
+          raise 'Unable to register - you must specify organization when using activation keys' if new_resource.organization.nil?
 
-        command << new_resource.activation_key.map { |key| "--activationkey=#{Shellwords.shellescape(key)}" }
-        command << "--org=#{Shellwords.shellescape(new_resource.organization)}"
-        command << '--force' if new_resource.force
+          command << new_resource.activation_key.map { |key| "--activationkey=#{Shellwords.shellescape(key)}" }
+          command << "--org=#{Shellwords.shellescape(new_resource.organization)}"
+          command << '--force' if new_resource.force
 
-        return command.join(' ')
+          return command.join(' ')
+        end
       end
 
       if new_resource.username && new_resource.password


### PR DESCRIPTION
### Description
Registration with username/password using the following resource definition was failing:
```
rhsm_register 'myhost' do
 username 'myuser'
 password 'mypassword'
 environment 'myenvironment'
 auto_attach true
end
```
The error:
```
NoMethodError
   -------------
   undefined method `empty?' for nil:NilClass
   
   Cookbook Trace:
   ---------------
   /var/chef/cache/cookbooks/redhat_subscription_manager/libraries/helpers.rb:26:in `register_command'
   /var/chef/cache/cookbooks/redhat_subscription_manager/libraries/rhsm_register.rb:58:in `block (2 levels) in <class:RhsmRegister>'
   /var/chef/cache/cookbooks/redhat_subscription_manager/libraries/rhsm_register.rb:56:in `block in <class:RhsmRegister>'
```
was traced back to the helper method code:
```
unless new_resource.activation_key.empty?
```
Since `activation_key` is not a REQUIRED property, if it doesn't exist, there is no `empty?` method available for it. The existence of this property must first be checked before determining if it is `empty?`.



### Issues Resolved

#40 

### Check List

- [X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
